### PR TITLE
Add empty constructor for Distribution PathMapping and Property

### DIFF
--- a/src/main/java/org/jfrog/filespecs/distribution/PathMapping.java
+++ b/src/main/java/org/jfrog/filespecs/distribution/PathMapping.java
@@ -2,9 +2,14 @@ package org.jfrog.filespecs.distribution;
 
 import java.util.Objects;
 
+@SuppressWarnings("unused")
 public class PathMapping {
     private String input;
     private String output;
+
+    // Empty constructor for serialization
+    public PathMapping() {
+    }
 
     public PathMapping(String input, String output) {
         this.input = input;

--- a/src/main/java/org/jfrog/filespecs/properties/Property.java
+++ b/src/main/java/org/jfrog/filespecs/properties/Property.java
@@ -3,9 +3,14 @@ package org.jfrog.filespecs.properties;
 import java.util.Objects;
 import java.util.Set;
 
+@SuppressWarnings("unused")
 public class Property {
     private String key;
     private Set<String> values;
+
+    // Default constructor for serialization
+    public Property() {
+    }
 
     public Property(String key, Set<String> values) {
         this.key = key;


### PR DESCRIPTION
When the ObjectMapper starts to deserialize an object, it first creates it with the default constructor. If the default constructor is missing, an exception is raised:

> Cannot construct instance of `org.jfrog.filespecs.properties.Property` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: (org.apache.http.conn.EofSensorInputStream); line: 1, column: 781] (through reference chain: org.jfrog.build.extractor.clientConfiguration.client.distribution.response.GetReleaseBundleVersionResponse["spec"]->org.jfrog.build.extractor.clientConfiguration.client.distribution.types.ReleaseBundleSpec["queries"]->java.util.ArrayList[0]->org.jfrog.build.extractor.clientConfiguration.client.distribution.types.ReleaseBundleQuery["added_props"]->java.util.ArrayList[0])
