### PR TITLE
Make InvalidFileSpecException extend IOException

### DIFF
--- a/src/main/java/org/jfrog/filespecs/entities/InvalidFileSpecException.java
+++ b/src/main/java/org/jfrog/filespecs/entities/InvalidFileSpecException.java
@@ -1,6 +1,8 @@
 package org.jfrog.filespecs.entities;
 
-public class InvalidFileSpecException extends Exception {
+import java.io.IOException;
+
+public class InvalidFileSpecException extends IOException {
     public InvalidFileSpecException(String message) {
         super(message);
     }


### PR DESCRIPTION
For convenience, InvalidFileSpecException should be IOException