### PR TITLE
Publish JARs to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,8 @@ plugins {
     // Apply the java-library plugin for API and implementation separation.
     id 'java-library'
     id 'maven-publish'
+    id 'signing'
+    id "io.github.gradle-nexus.publish-plugin" version "1.1.0"
 }
 
 group 'org.jfrog.filespecs'
@@ -55,11 +57,47 @@ task javadocJar(type: Jar) {
 }
 
 publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            artifact sourcesJar
-            artifact javadocJar
-            from components.java
+    def publication = publications.create("mavenJava", MavenPublication) {
+        artifact sourcesJar
+        artifact javadocJar
+        from components.java
+
+        pom {
+            name = project.name
+            description = project.description ?: "JFrog File Spec Java"
+            url = 'https://www.jfrog.com/confluence/display/JFROG/Using+File+Specs'
+
+            licenses {
+                license {
+                    name = 'The Apache License, Version 2.0'
+                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                }
+            }
+            developers {
+                developer {
+                    name = 'JFrog'
+                    email = 'eco-system@jfrog.com'
+                }
+            }
+            scm {
+                connection = 'scm:git:git://github.com/jfrog/file-specs-java.git'
+                developerConnection = 'scm:git:git@github.com:jfrog/file-specs-java.git'
+                url = 'https://github.com/jfrog/file-specs-java'
+            }
         }
     }
+    signing {
+        required { project.hasProperty('sign') }
+        def signingKey = findProperty("signingKey")
+        def signingPassword = findProperty("signingPassword")
+        useInMemoryPgpKeys(signingKey, signingPassword)
+        sign publication
+    }
+
+    if (project.plugins.hasPlugin('Artifactory')) {
+        artifactoryPublish {
+            publications(publication)
+        }
+    }
+
 }

--- a/ci/pipelines.release.yml
+++ b/ci/pipelines.release.yml
@@ -24,6 +24,7 @@ pipelines:
           integrations:
             - name: releases_temp
             - name: github_generic
+            - name: mvn_central
         execution:
           onStart:
             - *UPDATE_COMMIT_STATUS
@@ -67,6 +68,14 @@ pipelines:
               JFROG_CLI_BUILD_NAME=$JFROG_CLI_BUILD_NAME
               JFROG_CLI_BUILD_NUMBER=$JFROG_CLI_BUILD_NUMBER
               ./jfrog rt gradle clean build -x test artifactoryPublish
+
+            # Publish to Maven Central
+            - >
+              ORG_GRADLE_PROJECT_sonatypeUsername=$int_mvn_central_user
+              ORG_GRADLE_PROJECT_sonatypePassword=$int_mvn_central_password
+              ORG_GRADLE_PROJECT_signingKey=$(echo $int_mvn_central_signingKey | base64 -d)
+              ORG_GRADLE_PROJECT_signingPassword=$int_mvn_central_signingPassword
+              ./gradlew clean build publishToSonatype closeAndReleaseSonatypeStagingRepository -x test -Psign
 
             # Update next development version
             - sed -i "s/\(currentVersion=\).*\$/\1${NEXT_DEVELOPMENT_VERSION}/" gradle.properties


### PR DESCRIPTION
Publish to Maven Central to allow downloading the JAR when resolving the Gradle Artifactory plugin dependencies.

Resolves https://github.com/jfrog/build-info/issues/522