### PR TITLE
Update apache commons-lang (2) to current commons-lang3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ repositories {
 dependencies {
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.10.5'
-    implementation 'commons-lang:commons-lang:2.4'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 
     testImplementation 'org.testng:testng:7.1.0'
     testImplementation 'commons-io:commons-io:2.8.0'

--- a/src/main/java/org/jfrog/filespecs/FileSpecsParsingUtils.java
+++ b/src/main/java/org/jfrog/filespecs/FileSpecsParsingUtils.java
@@ -1,7 +1,7 @@
 package org.jfrog.filespecs;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jfrog.filespecs.entities.FilesGroup;
 
 public class FileSpecsParsingUtils {

--- a/src/main/java/org/jfrog/filespecs/FileSpecsValidation.java
+++ b/src/main/java/org/jfrog/filespecs/FileSpecsValidation.java
@@ -1,7 +1,7 @@
 package org.jfrog.filespecs;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jfrog.filespecs.entities.FilesGroup;
 import org.jfrog.filespecs.entities.InvalidFileSpecException;
 import org.jfrog.filespecs.utils.Log;

--- a/src/main/java/org/jfrog/filespecs/aql/AqlBuildingUtils.java
+++ b/src/main/java/org/jfrog/filespecs/aql/AqlBuildingUtils.java
@@ -1,7 +1,7 @@
 package org.jfrog.filespecs.aql;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/org/jfrog/filespecs/aql/PatternParsingUtils.java
+++ b/src/main/java/org/jfrog/filespecs/aql/PatternParsingUtils.java
@@ -1,6 +1,6 @@
 package org.jfrog.filespecs.aql;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/jfrog/filespecs/distribution/PathMappingGenerator.java
+++ b/src/main/java/org/jfrog/filespecs/distribution/PathMappingGenerator.java
@@ -1,7 +1,7 @@
 package org.jfrog.filespecs.distribution;
 
 import org.jfrog.filespecs.entities.FilesGroup;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/main/java/org/jfrog/filespecs/entities/FilesGroup.java
+++ b/src/main/java/org/jfrog/filespecs/entities/FilesGroup.java
@@ -1,7 +1,7 @@
 package org.jfrog.filespecs.entities;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.Arrays;
 

--- a/src/main/java/org/jfrog/filespecs/properties/PropertiesParser.java
+++ b/src/main/java/org/jfrog/filespecs/properties/PropertiesParser.java
@@ -1,6 +1,6 @@
 package org.jfrog.filespecs.properties;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.*;
 import java.util.stream.Collectors;


### PR DESCRIPTION
See issue https://github.com/jfrog/jenkins-artifactory-plugin/issues/556, PR https://github.com/jfrog/jenkins-artifactory-plugin/pull/567 was not sufficient to ensure commons-lang 2 is not included in the libs of the built plugin, it should also be removed from the dependant projects, including this one.